### PR TITLE
Update unirest library to new org name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.2'
     compileOnly 'org.projectlombok:lombok:1.18.2'
 
-    implementation 'com.mashape.unirest:unirest-java:1.4.9'
+    implementation 'com.konghq:unirest-java:3.14.1'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
     implementation 'org.slf4j:slf4j-api:1.7.25'

--- a/src/main/java/com/boclips/kalturaclient/http/UploadFileDescriptor.java
+++ b/src/main/java/com/boclips/kalturaclient/http/UploadFileDescriptor.java
@@ -2,18 +2,14 @@ package com.boclips.kalturaclient.http;
 
 import lombok.Builder;
 import lombok.Data;
-import org.apache.http.entity.ContentType;
-
 import java.io.InputStream;
+import kong.unirest.ContentType;
 
 @Builder
 @Data
 public class UploadFileDescriptor {
-
     private InputStream fileStream;
     private String filename;
     private String fieldName;
     private ContentType contentType;
-
-
 }

--- a/src/main/java/com/boclips/kalturaclient/http/UploadFileDescriptor.java
+++ b/src/main/java/com/boclips/kalturaclient/http/UploadFileDescriptor.java
@@ -1,9 +1,10 @@
 package com.boclips.kalturaclient.http;
 
+import kong.unirest.ContentType;
 import lombok.Builder;
 import lombok.Data;
+
 import java.io.InputStream;
-import kong.unirest.ContentType;
 
 @Builder
 @Data

--- a/src/main/java/com/boclips/kalturaclient/session/SessionRetriever.java
+++ b/src/main/java/com/boclips/kalturaclient/session/SessionRetriever.java
@@ -1,8 +1,8 @@
 package com.boclips.kalturaclient.session;
 
 import com.boclips.kalturaclient.config.KalturaClientConfig;
-import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
+import kong.unirest.Unirest;
+import kong.unirest.UnirestException;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor

--- a/src/main/java/com/boclips/kalturaclient/thumbnailAsset/ThumbnailAssetAddClient.java
+++ b/src/main/java/com/boclips/kalturaclient/thumbnailAsset/ThumbnailAssetAddClient.java
@@ -3,11 +3,10 @@ package com.boclips.kalturaclient.thumbnailAsset;
 import com.boclips.kalturaclient.http.KalturaRestClient;
 import com.boclips.kalturaclient.http.UploadFileDescriptor;
 import com.boclips.kalturaclient.thumbnailAsset.resources.ThumbnailAssetAddResource;
-import org.apache.http.entity.ContentType;
-
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import kong.unirest.ContentType;
 
 public class ThumbnailAssetAddClient implements ThumbnailAssetAdd {
     private final KalturaRestClient client;

--- a/src/main/java/com/boclips/kalturaclient/thumbnailAsset/ThumbnailAssetAddClient.java
+++ b/src/main/java/com/boclips/kalturaclient/thumbnailAsset/ThumbnailAssetAddClient.java
@@ -3,10 +3,11 @@ package com.boclips.kalturaclient.thumbnailAsset;
 import com.boclips.kalturaclient.http.KalturaRestClient;
 import com.boclips.kalturaclient.http.UploadFileDescriptor;
 import com.boclips.kalturaclient.thumbnailAsset.resources.ThumbnailAssetAddResource;
+import kong.unirest.ContentType;
+
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
-import kong.unirest.ContentType;
 
 public class ThumbnailAssetAddClient implements ThumbnailAssetAdd {
     private final KalturaRestClient client;


### PR DESCRIPTION
Old unirest has vulnerable dependencies, kong is the new name of mashape.

~~This currently fails on the same caption contract test that `main` is currently failing on.~~ Fixed the issue with the failing test on the Kaltura side.